### PR TITLE
fixed a typo in an environment variable name CONTENTFUL_ACCESS_TOKEN …

### DIFF
--- a/bin/setup.js
+++ b/bin/setup.js
@@ -44,7 +44,7 @@ const questions = [
   },
   {
     name: "accessToken",
-    when: !argv.accessToken && !process.env.CONTENTFUL_ACCESS_TOKEN_TOKEN,
+    when: !argv.accessToken && !process.env.CONTENTFUL_ACCESS_TOKEN,
     message: "Your Content Delivery API access token",
   },
 ]


### PR DESCRIPTION
### Issue
When running a command `npm run setup` an environment variable **CONTENTFUL_ACCESS_TOKEN** was ignored due to a typo **TOKEN_TOKEN** in its name in **./bin/setup.js** script at line 47.

A corresponding code snippet from **./bin/setup.js** script: 
`

    name: "accessToken",
    when: !argv.accessToken && !process.env.CONTENTFUL_ACCESS_TOKEN_TOKEN,
    message: "Your Content Delivery API access token",

`

### Fix
A suggested commit description:

A link to the **commit** [https://github.com/lerkasan/gatsby-contentful-portfolio/commit/4685e9cbfab23faa3bb473d88fa3d71e36523c3f](https://github.com/lerkasan/gatsby-contentful-portfolio/commit/4685e9cbfab23faa3bb473d88fa3d71e36523c3f)

A **diff** compared to a previous commit in the master branch: [https://github.com/lerkasan/gatsby-contentful-portfolio/compare/ad0ec10..4685e9c](https://github.com/lerkasan/gatsby-contentful-portfolio/compare/ad0ec10..4685e9c)