### PR TITLE
Added Stackbit.yaml to enable stackbit auto site creation and on page editing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,4 @@ CONTENTFUL_SPACE_ID=''
 CONTENTFUL_ACCESS_TOKEN=''
 
 # https://www.gatsbyjs.org/packages/gatsby-plugin-mailchimp/?=mailchimp#mailchimp-endpoint
-MAILCHIMP_ENDPOINT=''
+# MAILCHIMP_ENDPOINT=''

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 Live demo is available at:
 https://gatsby-contentful-portfolio.netlify.com/
 
+Click the button below to create a new site from this theme using Stackbit:
+
+[![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/youvalv/gatsby-contentful-portfolio&utm_source=theme-readme&utm_medium=referral&utm_campaign=stackbit_themes)
+
 ## Screenshot
 
 ![The home page](screenshot.png?raw=true)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ https://gatsby-contentful-portfolio.netlify.com/
 
 Click the button below to create a new site from this theme using Stackbit:
 
-[![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/youvalv/gatsby-contentful-portfolio&utm_source=theme-readme&utm_medium=referral&utm_campaign=stackbit_themes)
+[![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/youvalv/gatsby-contentful-portfolio&utm_source=theme-readme&utm_medium=referral)
 
 ## Screenshot
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -45,12 +45,12 @@ module.exports = {
     },
     `gatsby-transformer-sharp`,
     `gatsby-plugin-sharp`,
-    {
-      resolve: "gatsby-plugin-mailchimp",
-      options: {
-        endpoint: process.env.MAILCHIMP_ENDPOINT,
-      },
-    },
+    // {
+    //   resolve: "gatsby-plugin-mailchimp",
+    //   options: {
+    //     endpoint: process.env.MAILCHIMP_ENDPOINT,
+    //   },
+    // },
     {
       resolve: `gatsby-plugin-manifest`,
       options: {

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -1,0 +1,28 @@
+# The stackbit.yaml file lets you define the characteristic of your website
+# needed to make your theme, or project, work with Stackbit. For more info about
+# stackbit.yaml configuration visit https://www.stackbit.com/docs/stackbit-yaml/
+stackbitVersion: ~0.3.0
+ssgName: gatsby
+cmsName: contentful
+
+# The "buildCommand" and the "publishDir" properties are used to configure the
+# serverless deployment platform when Stackbit creates a new site from this theme.
+buildCommand: npm run build
+publishDir: out
+
+# The "import" object defines how Stackbit should provision Contentful when
+# creating a new site from this theme via https://app.stackbit.com/create.
+import:
+  type: contentful
+  contentFile: contentful/export.json
+  spaceIdEnvVar: CONTENTFUL_SPACE_ID
+  accessTokenEnvVar: CONTENTFUL_ACCESS_TOKEN
+
+# To allow creating and duplicating pages in Stackbit Studio, as well as other
+# advanced editing capabilities, specify which models describe your website
+# pages and specify their "urlPath" patterns. The urlPath should have the same
+# logic used in createPage in gatsby-node.js
+models:
+  blogPost:
+    type: page
+    urlPath: '/blog/{slug}'

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -8,7 +8,7 @@ cmsName: contentful
 # The "buildCommand" and the "publishDir" properties are used to configure the
 # serverless deployment platform when Stackbit creates a new site from this theme.
 buildCommand: npm run build
-publishDir: out
+publishDir: public
 
 # The "import" object defines how Stackbit should provision Contentful when
 # creating a new site from this theme via https://app.stackbit.com/create.

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -23,6 +23,6 @@ import:
 # pages and specify their "urlPath" patterns. The urlPath should have the same
 # logic used in createPage in gatsby-node.js
 models:
-  blogPost:
+  portfolio:
     type: page
-    urlPath: '/blog/{slug}'
+    urlPath: '/{slug}'


### PR DESCRIPTION
Also, optionally this can be added to the readme file once the stackbit.yaml is added (to allow direct site creation)

> Click the button below to create a new site from this theme using Stackbit:
> 
> [![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/wkocjan/gatsby-contentful-portfolio&utm_source=theme-readme&utm_medium=referral)
> 